### PR TITLE
Bulk of enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,8 @@ jdk:
   - oraclejdk8
   - oraclejdk7
   - openjdk7
-  - openjdk6
+  # Disabled due to https://github.com/HaxeFoundation/haxe/issues/4220
+  # - openjdk6
 
 env:
   matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ scala:
 jdk:
   - oraclejdk8
   - oraclejdk7
-  - oraclejdk6
-  - openjdk8
   - openjdk7
   - openjdk6
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ scala:
 jdk:
   - oraclejdk8
   - oraclejdk7
+  - oraclejdk6
   - openjdk7
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,9 @@ jdk:
   - oraclejdk8
   - oraclejdk7
   - oraclejdk6
+  - openjdk8
   - openjdk7
+  - openjdk6
 
 env:
   matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,6 @@ before_install:
  - if [[ "$SBT_TEST_CONFIGURATION" = "csharp-test" ]]; then travis_retry haxelib git HUGS https://github.com/qifun/HUGS.git; fi
  - travis_retry haxelib install continuation
  - travis_retry haxelib git hxparse https://github.com/Simn/hxparse.git development src
- - travis_retry haxelib git haxeparser https://github.com/qifun/haxeparser qifun.git src
+ - travis_retry haxelib git haxeparser https://github.com/qifun/haxeparser.git qifun src
 
 script: sbt ++$TRAVIS_SCALA_VERSION $SBT_TEST_CONFIGURATION:test

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,10 @@ jdk:
 
 env:
   matrix:
+    # The lastest Haxe
     - SBT_TEST_CONFIGURATION=test HAXE_FILE=haxe_latest.tar.gz
+    # Haxe 3.2.0
+    - SBT_TEST_CONFIGURATION=test HAXE_FILE=haxe_2015-05-12_master_77d171b.tar.gz
     # Disable test cases for old Haxe version
     # - SBT_TEST_CONFIGURATION=test HAXE_FILE=haxe_2014-09-19_development_9f5b3f5.tar.gz
     - SBT_TEST_CONFIGURATION=test HAXE_FILE=haxe_2014-10-21_development_a05b532.tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,10 @@ jdk:
 
 env:
   matrix:
-    # The lastest Haxe
     - SBT_TEST_CONFIGURATION=test HAXE_FILE=haxe_latest.tar.gz
-    # Haxe 3.2.0
-    - SBT_TEST_CONFIGURATION=test HAXE_FILE=haxe_2015-05-12_master_77d171b.tar.gz
+    # Disable test cases for old Haxe version
+    # - SBT_TEST_CONFIGURATION=test HAXE_FILE=haxe_2014-09-19_development_9f5b3f5.tar.gz
+    - SBT_TEST_CONFIGURATION=test HAXE_FILE=haxe_2014-10-21_development_a05b532.tar.gz
     # Disable currently, because of https://github.com/qifun/sbt-haxe/issues/8
     # - SBT_TEST_CONFIGURATION=csharp-test HAXE_FILE=haxe_latest.tar.gz
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ jdk:
 
 env:
   matrix:
-    # The lastest Haxe
-    - SBT_TEST_CONFIGURATION=test HAXE_FILE=haxe_latest.tar.gz
+    # The lastest Haxe, disabled due to https://github.com/HaxeFoundation/haxe/issues/4235
+    # - SBT_TEST_CONFIGURATION=test HAXE_FILE=haxe_latest.tar.gz
     # Haxe 3.2.0
     - SBT_TEST_CONFIGURATION=test HAXE_FILE=haxe_2015-05-12_master_77d171b.tar.gz
     # Disable test cases for old Haxe version

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,10 @@ jdk:
 
 env:
   matrix:
+    # The lastest Haxe
     - SBT_TEST_CONFIGURATION=test HAXE_FILE=haxe_latest.tar.gz
-    # Disable test cases for old Haxe version
-    # - SBT_TEST_CONFIGURATION=test HAXE_FILE=haxe_2014-09-19_development_9f5b3f5.tar.gz
-    - SBT_TEST_CONFIGURATION=test HAXE_FILE=haxe_2014-10-21_development_a05b532.tar.gz
+    # Haxe 3.2.0
+    - SBT_TEST_CONFIGURATION=test HAXE_FILE=haxe_2015-05-12_master_77d171b.tar.gz
     # Disable currently, because of https://github.com/qifun/sbt-haxe/issues/8
     # - SBT_TEST_CONFIGURATION=csharp-test HAXE_FILE=haxe_latest.tar.gz
 

--- a/src/haxe/com/qifun/jsonStream/GeneratorUtilities.hx
+++ b/src/haxe/com/qifun/jsonStream/GeneratorUtilities.hx
@@ -33,7 +33,11 @@ class GeneratorUtilities
 {
   private static function jsonFieldName(field:ClassField):String return
   {
+    #if haxe_320
     switch (field.meta.extract(":jsonFieldName"))
+    #else
+    switch (field.meta.get().filter(function (entry) return entry.name == ":jsonFieldName"))
+    #end
     {
       case []:
       {

--- a/src/haxe/com/qifun/jsonStream/GeneratorUtilities.hx
+++ b/src/haxe/com/qifun/jsonStream/GeneratorUtilities.hx
@@ -29,58 +29,53 @@ using Lambda;
 
 @:dox(hide)
 @:allow(com.qifun.jsonStream)
-class GeneratorUtilities
-{
+class GeneratorUtilities {
   private static function jsonFieldName(field:ClassField):String return
   {
-    #if haxe_320
+#if haxe_320
     switch (field.meta.extract(":jsonFieldName"))
-    #else
-    switch (field.meta.get().filter(function (entry) return entry.name == ":jsonFieldName"))
-    #end
+#else
+    switch (field.meta.get().filter(function(entry) return entry.name == ":jsonFieldName"))
+#end
     {
       case []:
-      {
-        field.name;
-      }
-      case [ jsonFieldNameEntry ]:
-      {
-        switch (jsonFieldNameEntry.params)
         {
-          case [ { expr:EConst(CString(value))} ]:
+          field.name;
+        }
+      case [ jsonFieldNameEntry ]:
+        {
+          switch (jsonFieldNameEntry.params)
           {
-            value;
-          }
-          default:
-          {
-            Context.error("Expect exactly one string literal parameter for @:jsonFieldName", Context.currentPos());
+            case [ { expr:EConst(CString(value))} ]:
+              {
+                value;
+              }
+            default:
+              {
+                Context.error("Expect exactly one string literal parameter for @:jsonFieldName", Context.currentPos());
+              }
           }
         }
-      }
       default:
-      {
-        Context.error("Duplicated metadata @:jsonFieldName", Context.currentPos());
-      }
+        {
+          Context.error("Duplicated metadata @:jsonFieldName", Context.currentPos());
+        }
     }
   }
 
   private static function hasConstructor(classType:ClassType):Bool return
   {
     var constructor = classType.constructor;
-    if (constructor == null)
-    {
+    if (constructor == null) {
       var superClass = classType.superClass;
-      if (superClass == null)
-      {
+      if (superClass == null) {
         false;
       }
-      else
-      {
+      else {
         hasConstructor(classType.superClass.t.get());
       }
     }
-    else
-    {
+    else {
       true;
     }
   }
@@ -98,10 +93,9 @@ class GeneratorUtilities
 
   private static function get_lowPriorityDynamicType():Type return
   {
-    if (_lowPriorityDynamicType == null)
-    {
+    if (_lowPriorityDynamicType == null) {
       _lowPriorityDynamicType =
-        Context.getType("com.qifun.jsonStream.LowPriorityDynamic");
+      Context.getType("com.qifun.jsonStream.LowPriorityDynamic");
     }
     _lowPriorityDynamicType;
   }
@@ -112,10 +106,9 @@ class GeneratorUtilities
 
   private static function get_hasUnknownTypeFieldType():Type return
   {
-    if (_hasUnknownTypeFieldType == null)
-    {
+    if (_hasUnknownTypeFieldType == null) {
       _hasUnknownTypeFieldType =
-        Context.getType("com.qifun.jsonStream.unknown.UnknownType.HasUnknownTypeField");
+      Context.getType("com.qifun.jsonStream.unknown.UnknownType.HasUnknownTypeField");
     }
     _hasUnknownTypeFieldType;
   }
@@ -126,29 +119,26 @@ class GeneratorUtilities
 
   private static function get_hasUnknownTypeSetterType():Type return
   {
-    if (_hasUnknownTypeSetterType == null)
-    {
+    if (_hasUnknownTypeSetterType == null) {
       _hasUnknownTypeSetterType =
-        Context.getType("com.qifun.jsonStream.unknown.UnknownType.HasUnknownTypeSetter");
+      Context.getType("com.qifun.jsonStream.unknown.UnknownType.HasUnknownTypeSetter");
     }
     _hasUnknownTypeSetterType;
   }
 
   private static var VOID_COMPLEX_TYPE(default, never) =
-    TPath({ name: "Void", pack: []});
+  TPath({ name: "Void", pack: []});
 
   private static var DYNAMIC_COMPLEX_TYPE(default, never) =
-    TPath({ name: "Dynamic", pack: []});
+  TPath({ name: "Dynamic", pack: []});
 
   private static function getFullName(module:String, name:String):String return
   {
     var lastDot = module.lastIndexOf(".");
-    if (lastDot == -1)
-    {
+    if (lastDot == -1) {
       name;
     }
-    else
-    {
+    else {
       '${module.substring(0, lastDot)}.$name';
     }
   }

--- a/src/haxe/com/qifun/jsonStream/GeneratorUtilities.hx
+++ b/src/haxe/com/qifun/jsonStream/GeneratorUtilities.hx
@@ -31,6 +31,35 @@ using Lambda;
 @:allow(com.qifun.jsonStream)
 class GeneratorUtilities
 {
+  private static function jsonFieldName(field:ClassField):String return
+  {
+    switch (field.meta.extract(":jsonFieldName"))
+    {
+      case []:
+      {
+        field.name;
+      }
+      case [ jsonFieldNameEntry ]:
+      {
+        switch (jsonFieldNameEntry.params)
+        {
+          case [ { expr:EConst(CString(value))} ]:
+          {
+            value;
+          }
+          default:
+          {
+            Context.error("Expect exactly one string literal parameter for @:jsonFieldName", Context.currentPos());
+          }
+        }
+      }
+      default:
+      {
+        Context.error("Duplicated metadata @:jsonFieldName", Context.currentPos());
+      }
+    }
+  }
+
   private static function hasConstructor(classType:ClassType):Bool return
   {
     var constructor = classType.constructor;

--- a/src/haxe/com/qifun/jsonStream/JsonBuilderFactory.hx
+++ b/src/haxe/com/qifun/jsonStream/JsonBuilderFactory.hx
@@ -887,10 +887,11 @@ class JsonBuilderFactoryGenerator
             hasUnknownFieldMap = true;
           case { kind: FVar(AccNormal | AccNo, AccNormal | AccNo), meta: meta } if (!meta.has(":transient")):
             var fieldName = field.name;
+            var jsonFieldName = GeneratorUtilities.jsonFieldName(field);
             var d = resolvedBuild(TypeTools.toComplexType(applyTypeParameters(field.type)), macro value, params);
             cases.push(
               {
-                values: [ macro $v{fieldName} ],
+                values: [ macro $v{jsonFieldName} ],
                 guard: null,
                 expr: macro result.$fieldName = @await $d(),
               });

--- a/src/haxe/com/qifun/jsonStream/JsonDeserializer.hx
+++ b/src/haxe/com/qifun/jsonStream/JsonDeserializer.hx
@@ -436,8 +436,7 @@ class JsonDeserializerGenerator
                   parameterCases,
                   if (unknownFieldMapName == null)
                   {
-                    expr: EBlock([]),
-                    pos: Context.currentPos(),
+                    macro com.qifun.jsonStream.JsonDeserializer.JsonDeserializerRuntime.skip(parameterPair.value);
                   }
                   else
                   {
@@ -508,7 +507,7 @@ class JsonDeserializerGenerator
         cases,
         if (unknownEnumValueConstructor == null)
         {
-          macro null;
+          macro com.qifun.jsonStream.JsonDeserializer.JsonDeserializerRuntime.skip(parameterPair.value);
         }
         else
         {
@@ -758,7 +757,7 @@ class JsonDeserializerGenerator
               }
               else
               {
-                macro null;
+                macro com.qifun.jsonStream.JsonDeserializer.JsonDeserializerRuntime.skip(pair.value);
               }),
           }
 
@@ -1337,6 +1336,48 @@ abstract JsonDeserializerPluginStream<ResultType>(JsonStream)
 @:final
 class JsonDeserializerRuntime
 {
+
+  @:noUsing
+  public static function skip(stream:JsonStream):Void
+  {
+    switch (stream)
+    {
+      case OBJECT(pairs):
+        var generator = Std.instance(pairs, (Generator:Class<Generator<JsonStream.JsonStreamPair>>));
+        if (generator != null)
+        {
+          for (pair in generator)
+          {
+            skip(pair.value);
+          }
+        }
+        else
+        {
+          for (pair in pairs)
+          {
+            skip(pair.value);
+          }
+        }
+      case ARRAY(elements):
+        var generator = Std.instance(elements, (Generator:Class<Generator<JsonStream>>));
+        if (generator != null)
+        {
+          for (element in generator)
+          {
+            skip(element);
+          }
+        }
+        else
+        {
+          for (element in elements)
+          {
+            skip(element);
+          }
+        }
+      default:
+        // Do nothing
+    }
+  }
 
   @:noUsing
   public static inline function toInt64(d:Dynamic):Int64 return

--- a/src/haxe/com/qifun/jsonStream/JsonDeserializer.hx
+++ b/src/haxe/com/qifun/jsonStream/JsonDeserializer.hx
@@ -507,7 +507,7 @@ class JsonDeserializerGenerator
         cases,
         if (unknownEnumValueConstructor == null)
         {
-          macro com.qifun.jsonStream.JsonDeserializer.JsonDeserializerRuntime.skip(parameterPair.value);
+          macro com.qifun.jsonStream.JsonDeserializer.JsonDeserializerRuntime.skip(pair.value);
         }
         else
         {

--- a/src/haxe/com/qifun/jsonStream/JsonDeserializer.hx
+++ b/src/haxe/com/qifun/jsonStream/JsonDeserializer.hx
@@ -507,7 +507,11 @@ class JsonDeserializerGenerator
         cases,
         if (unknownEnumValueConstructor == null)
         {
-          macro com.qifun.jsonStream.JsonDeserializer.JsonDeserializerRuntime.skip(pair.value);
+          macro
+          {
+            com.qifun.jsonStream.JsonDeserializer.JsonDeserializerRuntime.skip(pair.value);
+            null;
+          }
         }
         else
         {

--- a/src/haxe/com/qifun/jsonStream/JsonDeserializer.hx
+++ b/src/haxe/com/qifun/jsonStream/JsonDeserializer.hx
@@ -699,10 +699,11 @@ class JsonDeserializerGenerator
                 {
                   // Workaround for https://github.com/HaxeFoundation/haxe/issues/3203
                   var fieldName = field.name;
+                  var jsonFieldName = GeneratorUtilities.jsonFieldName(field);
                   var d = resolvedDeserialize(TypeTools.toComplexType(applyTypeParameters(field.type)), macro pair.value, params);
                   cases.push(
                     {
-                      values: [ macro $v{fieldName} ],
+                      values: [ macro $v{jsonFieldName} ],
                       guard: null,
                       expr: macro result.$fieldName = com.qifun.jsonStream.JsonDeserializer.JsonDeserializerRuntime.toInt64($d),
                     });
@@ -710,10 +711,11 @@ class JsonDeserializerGenerator
                 case { kind: FVar(AccNormal | AccNo, AccNormal | AccNo), meta: meta } if (!meta.has(":transient")):
                 {
                   var fieldName = field.name;
+                  var jsonFieldName = GeneratorUtilities.jsonFieldName(field);
                   var d = resolvedDeserialize(TypeTools.toComplexType(applyTypeParameters(field.type)), macro pair.value, params);
                   cases.push(
                     {
-                      values: [ macro $v{fieldName} ],
+                      values: [ macro $v{jsonFieldName} ],
                       guard: null,
                       expr: macro result.$fieldName = $d,
                     });

--- a/src/haxe/com/qifun/jsonStream/JsonSerializer.hx
+++ b/src/haxe/com/qifun/jsonStream/JsonSerializer.hx
@@ -637,11 +637,12 @@ class JsonSerializerGenerator
           case { kind: FVar(AccNormal | AccNo, AccNormal | AccNo), meta: meta } if (!meta.has(":transient")):
           {
             var fieldName = field.name;
+            var jsonFieldName = GeneratorUtilities.jsonFieldName(field);
             var s = resolvedSerialize(TypeTools.toComplexType(applyTypeParameters(field.type)), macro data.$fieldName, params);
             blockExprs.push(
               macro if (com.qifun.jsonStream.JsonSerializer.JsonSerializerRuntime.isNotNull(data.$fieldName))
               {
-                @await yield(new com.qifun.jsonStream.JsonStream.JsonStreamPair($v{fieldName}, $s));
+                @await yield(new com.qifun.jsonStream.JsonStream.JsonStreamPair($v{jsonFieldName}, $s));
               });
           }
           case _:

--- a/src/haxe/com/qifun/jsonStream/deserializerPlugin/CrossPlatformDeserializerPlugins.hx
+++ b/src/haxe/com/qifun/jsonStream/deserializerPlugin/CrossPlatformDeserializerPlugins.hx
@@ -433,7 +433,7 @@ class CrossPlatformVectorDeserializerPlugin
       macro
       {
         var nativeStream = com.qifun.jsonStream.deserializerPlugin.CrossPlatformDeserializerPlugins.CrossPlatformVectorDeserializerPlugin.toNativeStream($self);
-        var nativeResult = com.qifun.jsonStream.deserializerPlugin.PrimitiveDeserializerPlugins.VectorDeserializerPlugin.deserializeForElement(nativeStream, function(a) return { var v = new haxe.ds.Vector(a.length); for (i in 0...a.length) v[i] = a[i]; v; }, function(substream) return substream.pluginDeserialize());
+        var nativeResult = com.qifun.jsonStream.deserializerPlugin.PrimitiveDeserializerPlugins.VectorDeserializerPlugin.deserializeForElement(nativeStream, function (a) return com.qifun.jsonStream.deserializerPlugin.PrimitiveDeserializerPlugins.VectorDeserializerPlugin.arrayToVector(a), function(substream) return substream.pluginDeserialize());
         new com.qifun.jsonStream.crossPlatformTypes.CrossVector(nativeResult);
       }
     }
@@ -473,7 +473,7 @@ class StmVectorDeserializerPlugin
       macro
       {
         var nativeStream = com.qifun.jsonStream.deserializerPlugin.CrossPlatformDeserializerPlugins.StmVectorDeserializerPlugin.toNativeStream($self);
-        var nativeResult = com.qifun.jsonStream.deserializerPlugin.PrimitiveDeserializerPlugins.VectorDeserializerPlugin.deserializeForElement(nativeStream, function(a) return { var v = new haxe.ds.Vector(a.length); for (i in 0...a.length) v[i] = a[i]; v; }, function(substream) return substream.pluginDeserialize());
+        var nativeResult = com.qifun.jsonStream.deserializerPlugin.PrimitiveDeserializerPlugins.VectorDeserializerPlugin.deserializeForElement(nativeStream, function (a) return com.qifun.jsonStream.deserializerPlugin.PrimitiveDeserializerPlugins.VectorDeserializerPlugin.arrayToVector(a), function(substream) return substream.pluginDeserialize());
         new com.qifun.jsonStream.crossPlatformTypes.StmVector(nativeResult);
       }
     }

--- a/src/haxe/com/qifun/jsonStream/deserializerPlugin/PrimitiveDeserializerPlugins.hx
+++ b/src/haxe/com/qifun/jsonStream/deserializerPlugin/PrimitiveDeserializerPlugins.hx
@@ -389,6 +389,14 @@ class VectorDeserializerPlugin
   @:overload
   @:noUsing
   @:dox(hide)
+  public static function setVectorElement(v:Vector<java.types.Char16>, index:Int, value:java.types.Char16)
+  {
+    v[index] = value;
+  }
+
+  @:overload
+  @:noUsing
+  @:dox(hide)
   public static function setVectorElement(v:Vector<java.types.Int8>, index:Int, value:java.types.Int8)
   {
     v[index] = value;

--- a/src/haxe/com/qifun/jsonStream/deserializerPlugin/PrimitiveDeserializerPlugins.hx
+++ b/src/haxe/com/qifun/jsonStream/deserializerPlugin/PrimitiveDeserializerPlugins.hx
@@ -350,12 +350,75 @@ class VectorDeserializerPlugin
     v;
   }
 
+  #if java
+  @:overload
+  #end
   @:noUsing
   @:dox(hide)
   public static function setVectorElement<Element>(v:Vector<Element>, index:Int, value:Element)
   {
     v[index] = value;
   }
+
+  #if java
+
+  @:overload
+  @:noUsing
+  @:dox(hide)
+  public static function setVectorElement(v:Vector<Bool>, index:Int, value:Bool)
+  {
+    v[index] = value;
+  }
+
+  @:overload
+  @:noUsing
+  @:dox(hide)
+  public static function setVectorElement(v:Vector<Float>, index:Int, value:Float)
+  {
+    v[index] = value;
+  }
+
+  @:overload
+  @:noUsing
+  @:dox(hide)
+  public static function setVectorElement(v:Vector<Single>, index:Int, value:Single)
+  {
+    v[index] = value;
+  }
+
+  @:overload
+  @:noUsing
+  @:dox(hide)
+  public static function setVectorElement(v:Vector<java.types.Int8>, index:Int, value:java.types.Int8)
+  {
+    v[index] = value;
+  }
+
+  @:overload
+  @:noUsing
+  @:dox(hide)
+  public static function setVectorElement(v:Vector<java.types.Int16>, index:Int, value:java.types.Int16)
+  {
+    v[index] = value;
+  }
+
+  @:overload
+  @:noUsing
+  @:dox(hide)
+  public static function setVectorElement(v:Vector<Int>, index:Int, value:Int)
+  {
+    v[index] = value;
+  }
+
+  @:overload
+  @:noUsing
+  @:dox(hide)
+  public static function setVectorElement(v:Vector<haxe.Int64>, index:Int, value:haxe.Int64)
+  {
+    v[index] = value;
+  }
+
+  #end
 
   macro public static function pluginDeserialize<Element>(self:ExprOf<JsonDeserializerPluginStream<Vector<Element>>>):ExprOf<Null<Vector<Element>>> return
   {

--- a/src/haxe/com/qifun/jsonStream/io/BsonInput.hx
+++ b/src/haxe/com/qifun/jsonStream/io/BsonInput.hx
@@ -34,7 +34,7 @@ abstract BsonInput(ReadableBuffer)
 
   public inline function readByte():Int
   {
-    var byte = new java.lang.Byte(this.readByte());
+    var byte = java.lang.Byte.valueOf(this.readByte());
     return byte.intValue();
   }
   

--- a/src/haxe/com/qifun/jsonStream/io/BsonInput.hx
+++ b/src/haxe/com/qifun/jsonStream/io/BsonInput.hx
@@ -34,7 +34,7 @@ abstract BsonInput(ReadableBuffer)
 
   public inline function readByte():Int
   {
-    var byte:java.lang.Byte = java.lang.Byte.valueOf(this.readByte());
+    var byte:java.lang.Byte = cast java.lang.Byte.valueOf(this.readByte());
     return byte.intValue();
   }
   

--- a/src/haxe/com/qifun/jsonStream/io/BsonInput.hx
+++ b/src/haxe/com/qifun/jsonStream/io/BsonInput.hx
@@ -34,7 +34,7 @@ abstract BsonInput(ReadableBuffer)
 
   public inline function readByte():Int
   {
-    var byte = java.lang.Byte.valueOf(this.readByte());
+    var byte:java.lang.Byte = java.lang.Byte.valueOf(this.readByte());
     return byte.intValue();
   }
   

--- a/src/haxe/com/qifun/jsonStream/serializerPlugin/PrimitiveSerializerPlugins.hx
+++ b/src/haxe/com/qifun/jsonStream/serializerPlugin/PrimitiveSerializerPlugins.hx
@@ -37,7 +37,7 @@ class Int64SerializerPlugin
   private static function toInt64(d:Dynamic):Int64 return
   {
     #if java
-    untyped __java__("(long)d");
+    untyped __java__("((java.lang.Number)d).longValue");
     #else
     d;
     #end

--- a/src/haxe/com/qifun/jsonStream/serializerPlugin/PrimitiveSerializerPlugins.hx
+++ b/src/haxe/com/qifun/jsonStream/serializerPlugin/PrimitiveSerializerPlugins.hx
@@ -37,7 +37,7 @@ class Int64SerializerPlugin
   private static function toInt64(d:Dynamic):Int64 return
   {
     #if java
-    untyped __java__("((java.lang.Number)d).longValue");
+    untyped __java__("((java.lang.Number)d).longValue()");
     #else
     d;
     #end

--- a/src/test-haxe/com/qifun/jsonStream/CustomJsonFieldNameEntities.hx
+++ b/src/test-haxe/com/qifun/jsonStream/CustomJsonFieldNameEntities.hx
@@ -1,0 +1,29 @@
+/*
+ * json-stream
+ * Copyright 2014 深圳岂凡网络有限公司 (Shenzhen QiFun Network Corp., LTD)
+ *
+ * Author: 杨博 (Yang Bo) <pop.atry@gmail.com>, 张修羽 (Zhang Xiuyu) <zxiuyu@126.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.qifun.jsonStream;
+
+@:final
+class CustomJsonFieldName
+{
+  public function new() {}
+
+  @:jsonFieldName("foo-bar")
+  public var fooBar:Int;
+}

--- a/src/test-haxe/com/qifun/jsonStream/CustomJsonFieldNameIo.hx
+++ b/src/test-haxe/com/qifun/jsonStream/CustomJsonFieldNameIo.hx
@@ -1,0 +1,36 @@
+/*
+ * json-stream
+ * Copyright 2014 深圳岂凡网络有限公司 (Shenzhen QiFun Network Corp., LTD)
+ *
+ * Author: 杨博 (Yang Bo) <pop.atry@gmail.com>, 张修羽 (Zhang Xiuyu) <zxiuyu@126.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.qifun.jsonStream;
+
+using com.qifun.jsonStream.Plugins;
+
+@:build(com.qifun.jsonStream.JsonSerializer.generateSerializer([
+  "com.qifun.jsonStream.CustomJsonFieldNameEntities",
+]))
+class CustomJsonFieldNameSerializer
+{
+}
+
+@:build(com.qifun.jsonStream.JsonDeserializer.generateDeserializer([
+    "com.qifun.jsonStream.CustomJsonFieldNameEntities",
+]))
+class CCustomJsonFieldNameDeserializer
+{
+}

--- a/src/test-haxe/com/qifun/jsonStream/CustomJsonFieldNameTest.hx
+++ b/src/test-haxe/com/qifun/jsonStream/CustomJsonFieldNameTest.hx
@@ -1,0 +1,47 @@
+/*
+ * json-stream
+ * Copyright 2014 深圳岂凡网络有限公司 (Shenzhen QiFun Network Corp., LTD)
+ *
+ * Author: 杨博 (Yang Bo) <pop.atry@gmail.com>, 张修羽 (Zhang Xiuyu) <zxiuyu@126.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.qifun.jsonStream;
+import haxe.unit.TestCase;
+import com.qifun.jsonStream.JsonSerializer;
+import com.qifun.jsonStream.JsonStream;
+import com.qifun.jsonStream.JsonDeserializer;
+import com.qifun.jsonStream.CustomJsonFieldNameEntities;
+import com.qifun.jsonStream.testUtil.JsonTestCase;
+import com.dongxiguo.continuation.utils.Generator;
+import com.dongxiguo.continuation.Continuation;
+import haxe.ds.Vector;
+
+using com.qifun.jsonStream.Plugins;
+using com.qifun.jsonStream.CustomJsonFieldNameIo;
+
+class CustomJsonFieldNameTest extends JsonTestCase
+{
+  function testCustomJsonField()
+  {
+    var entity = new CustomJsonFieldName();
+    entity.fooBar = 100;
+    var jsonStream1 = JsonSerializer.serialize(entity);
+    var raw = JsonDeserializer.deserializeRaw(jsonStream1);
+    assertEquals(100, Reflect.field(raw, "foo-bar"));
+    var jsonStream2 = JsonSerializer.serialize(entity);
+    var entity2:CustomJsonFieldName = JsonDeserializer.deserialize(jsonStream2);
+    assertDeepEquals(entity, entity2);
+  }
+}

--- a/src/test-haxe/com/qifun/jsonStream/TextTest.hx
+++ b/src/test-haxe/com/qifun/jsonStream/TextTest.hx
@@ -35,7 +35,11 @@ class TextTest extends JsonTestCase
   {
     var text = "{\"numberField\":-33.799232482910156}";
     var nativeData2:Dynamic = JsonDeserializer.deserializeRaw(TextParser.parseString(text));
+    #if haxe_320
     assertEquals(-33.799232482910156, nativeData2.numberField);
+    #else
+    assertTrue(Math.abs(-33.799232482910156 - nativeData2.numberField) < 0.000000000001);
+    #end
   }
 
   public function testParser()

--- a/src/test-haxe/com/qifun/jsonStream/TextTest.hx
+++ b/src/test-haxe/com/qifun/jsonStream/TextTest.hx
@@ -31,6 +31,13 @@ import haxe.io.StringInput;
 class TextTest extends JsonTestCase
 {
 
+  public function testNumberLiteral()
+  {
+    var text = "{\"numberField\":-33.799232482910156}";
+    var nativeData2:Dynamic = JsonDeserializer.deserializeRaw(TextParser.parseString(text));
+    assertEquals(-33.799232482910156, nativeData2.numberField);
+  }
+
   public function testParser()
   {
     var nativeData =

--- a/src/test-haxe/com/qifun/jsonStream/testUtil/JsonTestCase.hx
+++ b/src/test-haxe/com/qifun/jsonStream/testUtil/JsonTestCase.hx
@@ -146,14 +146,14 @@ class JsonTestCase extends TestCase
   }
 
   function assertDeepEquals(expected: Dynamic, actual: Dynamic, ?c : PosInfos):Void
- 	{
-		currentTest.done = true;
-		if (!JsonEquality.deepEquals(actual, expected)){
-			currentTest.success = false;
-			currentTest.error   = "expected '" + expected + "' but was '" + actual + "'";
-			currentTest.posInfos = c;
-			throw currentTest;
-		}
-	}
+  {
+    currentTest.done = true;
+    if (!JsonEquality.deepEquals(actual, expected)){
+      currentTest.success = false;
+      currentTest.error   = "expected '" + expected + "' but was '" + actual + "'";
+      currentTest.posInfos = c;
+      throw currentTest;
+    }
+  }
 
 }


### PR DESCRIPTION
1. Support `@:jsonFieldName("foo-bar")` annotation to map a JSON field to a Haxe field.
2. Avoid throwing error when the JSON data contains some unknown fields.
3. Add Travis test on Haxe 3.2.0 .
4. Remove Travis test on Haxe development branch, due to Haxe bug https://github.com/HaxeFoundation/haxe/issues/4235 .
5. Enable `Vector<T>` for Java targets.