### PR TITLE
Release 0.2.3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -61,7 +61,7 @@ organization := "com.qifun"
 
 name := "json-stream"
 
-version := "0.2.3"
+version := "0.2.4-SNAPSHOT"
 
 homepage := Some(url(s"https://github.com/qifun/${name.value}"))
 

--- a/build.sbt
+++ b/build.sbt
@@ -61,7 +61,7 @@ organization := "com.qifun"
 
 name := "json-stream"
 
-version := "0.2.3-SNAPSHOT"
+version := "0.2.3"
 
 homepage := Some(url(s"https://github.com/qifun/${name.value}"))
 


### PR DESCRIPTION
I have released 0.2.3 to Maven central repository: http://central.maven.org/maven2/com/qifun/json-stream_2.11/0.2.3/ http://central.maven.org/maven2/com/qifun/json-stream_2.10/0.2.3/

Please add a tag "0.2.3" to 030c569 via Web interface at https://github.com/qifun/stateless-future/releases/new